### PR TITLE
Add md5 hash function that produces hash for both the trimmed and pad…

### DIFF
--- a/XCI_Trimmer.py
+++ b/XCI_Trimmer.py
@@ -145,10 +145,10 @@ def md5sum(block_size=2**20):
             md5.update(padding)
         md5.update(pad_remainder)
 
-        suffix = ' [trim size: {}]'.format(filesize)
+        suffix = ' // trim size: {}'.format(filesize)
         print('{}  {}{}'.format(hash, filename, suffix))
 
-        suffix = ' [cart size: {}]'.format(cartsize)
+        suffix = ' // cart size: {}'.format(cartsize)
         hash = md5.hexdigest()
 
     print('{}  {}{}'.format(hash, filename, suffix))

--- a/XCI_Trimmer.py
+++ b/XCI_Trimmer.py
@@ -5,6 +5,7 @@
 # Purpose: Trims or pads extra bytes from XCI files
 
 import os
+import hashlib
 import argparse
 from shutil import copyfile
 
@@ -115,8 +116,45 @@ def pad():
         f.write(pad_remainder)
 
 
+# if rom is trimmed, output md5 hash of both trimmed and padded rom
+def md5sum(block_size=2**20):
+
+    trimmed = False
+    if filesize < cartsize:
+        trimmed = True
+
+    md5 = hashlib.md5()
+    with open(filename, 'rb') as f:
+        data = f.read(block_size)
+        while data:
+            md5.update(data)
+            data = f.read(block_size)
+    hash = md5.hexdigest()
+
+    suffix = ''
+    if trimmed:
+        padding = bytearray(b'\xFF' * block_size)
+        pad_remainder = bytearray()
+
+        i = cartsize - filesize
+        chunks = int(i/block_size)
+        remainder = i - (chunks * block_size)
+        pad_remainder += b'\xFF' * remainder
+
+        for _ in range(chunks):
+            md5.update(padding)
+        md5.update(pad_remainder)
+
+        suffix = ' [trim size: {}]'.format(filesize)
+        print('{}  {}{}'.format(hash, filename, suffix))
+
+        suffix = ' [cart size: {}]'.format(cartsize)
+        hash = md5.hexdigest()
+
+    print('{}  {}{}'.format(hash, filename, suffix))
+
+
 def main():
-    print('\n========== XCI Trimmer ==========\n')
 
     # Arg parser for program options
     parser = argparse.ArgumentParser(description='Trim or Pad XCI rom files')
@@ -124,6 +162,7 @@ def main():
     parser.add_argument('filename', help='Path to XCI rom file')
     group.add_argument('-t', '--trim', action='store_true', help='Trim excess bytes')
     group.add_argument('-p', '--pad', action='store_true', help='Restore excess bytes')
+    group.add_argument('-m', '--md5', action='store_true', help='Compute md5 hash')
     parser.add_argument('-c', '--copy', action='store_true', help='Creates a copy instead of modifying original file')
 
     # Check passed arguments
@@ -152,6 +191,12 @@ def main():
         print('ROM is improperly trimmed or padded. Aborting.\n')
         return 1
 
+    # mimic output of md5sum on linux
+    if args.md5:
+        md5sum()
+        return
+
+    print('\n========== XCI Trimmer ==========\n')
     print('ROM  Size:     {:5d} GiB'.format(ROM_size))
     print('Trim Size:     {:5.2f} GiB\n'.format(Data_size))
 


### PR DESCRIPTION
…ded rom

I was looking for a way to compare trimmed xci's to the Scene and No-Intro databases without padding them back out to produce a hash.  I found your excellent tool and adapted the code.  

I made the output mimic md5sum.  Examples:
```
python3 ~/src/XCI_Trimmer/XCI_Trimmer.py --md5 "0001 - Legend of Zelda, The - Breath of the Wild (World) (En,Ja,Fr,De,Es,It,Nl,Ru) [Trimmed].xci" 
1cfca1fe4936f895a3bda98e13c05e57  0001 - Legend of Zelda, The - Breath of the Wild (World) (En,Ja,Fr,De,Es,It,Nl,Ru) [Trimmed].xci [trim size: 14880118272]
796b310d054f23150b9995a80238f31d  0001 - Legend of Zelda, The - Breath of the Wild (World) (En,Ja,Fr,De,Es,It,Nl,Ru) [Trimmed].xci [cart size: 15971909632]

python3 ~/src/XCI_Trimmer/XCI_Trimmer.py --md5 "0008 - Cave Story+ (USA) [Trimmed].xci"
5cea9fc7d4e10c2c5b7d7adda6264488  0008 - Cave Story+ (USA) [Trimmed].xci [trim size: 544832512]
af8ac186efd0fa1a02d0c63c40dd2fd4  0008 - Cave Story+ (USA) [Trimmed].xci [cart size: 1996488704]
```

